### PR TITLE
The pprint dependency is not needed as pprint is part of python itself.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pytest
 requests
-pprint

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ setup(
     install_requires=[
         'requests',
         'pytest',
-        'pprint'
     ],
     download_url = 'https://github.com/leifdreizler/bugcrowd/archive/0.1.tar.gz',
     keywords = ['bugcrowd'],


### PR DESCRIPTION
Signed-off-by: David Black <dblack@atlassian.com>